### PR TITLE
fix: update dependencies to address security vulnerabilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,14 @@
         "php": "^7.2.5|^8.0",
         "fideloper/proxy": "^4.2",
         "fruitcake/laravel-cors": "^2.0",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^7.8",
         "laravel/framework": "^7.24",
         "laravel/tinker": "^2.0",
         "laravel/ui": "^2.5"
     },
     "require-dev": {
         "facade/ignition": "^2.0",
-        "fzaninotto/faker": "^1.9.1",
+        "fakerphp/faker": "^1.23",
         "mockery/mockery": "^1.3.1",
         "nunomaduro/collision": "^4.1",
         "phpunit/phpunit": "^8.5"

--- a/package.json
+++ b/package.json
@@ -10,17 +10,17 @@
         "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "devDependencies": {
-        "axios": "^0.19",
+        "axios": "^1.7.0",
         "bootstrap": "^4.0.0",
         "cross-env": "^7.0",
-        "jquery": "^3.2",
+        "jquery": "^3.7.0",
         "laravel-mix": "^5.0.1",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "popper.js": "^1.12",
         "resolve-url-loader": "^2.3.1",
         "sass": "^1.20.1",
         "sass-loader": "^8.0.0",
-        "vue": "^2.5.17",
-        "vue-template-compiler": "^2.6.10"
+        "vue": "^2.7.16",
+        "vue-template-compiler": "^2.7.16"
     }
 }


### PR DESCRIPTION
This PR addresses Dependabot security alerts by updating vulnerable dependencies:

## Changes
- Update guzzlehttp/guzzle from ^6.3 to ^7.8 (CVE fixes)
- Replace deprecated fzaninotto/faker with fakerphp/faker ^1.23
- Update axios from ^0.19 to ^1.7.0 (multiple CVE fixes)
- Update lodash from ^4.17.19 to ^4.17.21 (prototype pollution fix)
- Update jquery from ^3.2 to ^3.7.0 (XSS vulnerability fixes)
- Update vue and vue-template-compiler to ^2.7.16 (template vulnerabilities)

Closes #13

Generated with [Claude Code](https://claude.ai/code)