### PR TITLE
Update Docker ports to avoid conflicts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,13 +2,13 @@ APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_URL=http://localhost:8080
 
 LOG_CHANNEL=stack
 
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1
-DB_PORT=3306
+DB_PORT=3307
 DB_DATABASE=laravel
 DB_USERNAME=root
 DB_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -5,6 +5,65 @@ https://boardboard.tokyo
 ## 概要
 Laravelで作成したシンプルなQ&Aアプリ
 
+## ローカル開発環境セットアップ
+
+### 必要な環境
+- Docker
+- Docker Compose
+
+### セットアップ手順
+
+1. リポジトリをクローン
+```bash
+git clone https://github.com/enutake/board.git
+cd board
+```
+
+2. 環境変数ファイルを作成
+```bash
+cp .env.example .env
+```
+
+3. Dockerコンテナを起動
+```bash
+docker-compose up -d
+```
+
+4. 依存関係をインストール
+```bash
+docker-compose exec web composer install
+```
+
+5. アプリケーションキーを生成
+```bash
+docker-compose exec web php artisan key:generate
+```
+
+6. データベースマイグレーション
+```bash
+docker-compose exec web php artisan migrate
+```
+
+### アクセス情報
+- **アプリケーション**: http://localhost:8080
+- **HTTPS**: https://localhost:8443
+- **データベース**: localhost:3307（ユーザー: root, パスワード: 環境変数で設定）
+
+### よく使うコマンド
+```bash
+# コンテナの起動
+docker-compose up -d
+
+# コンテナの停止
+docker-compose down
+
+# ログの確認
+docker-compose logs
+
+# Webコンテナのシェルに入る
+docker-compose exec web bash
+```
+
 ## 設計
 下記のグーグルドライブ内に超最低限の資料が格納されています。
 https://drive.google.com/drive/folders/1E0qM00mzwVwDz93Uc23M2PQgc0QoxGOr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       - ./docker/web/root:/root
       - ./docker/web/workspace:/workspace
     ports:
-      - 80:80
-      - 443:443
+      - 8080:80
+      - 8443:443
     tty: true
   db:
     build: ./docker/db/
@@ -20,5 +20,5 @@ services:
       - ./docker/db/root:/root
       - ./docker/db/workspace:/workspace
     ports:
-      - 43306:3306
+      - 3307:3306
     tty: true


### PR DESCRIPTION
Update Docker ports to avoid conflicts with other environments

## 変更内容
- Webサーバーポート: 80:80, 443:443 → 8080:80, 8443:443
- データベースポート: 43306:3306 → 3307:3306
- .env.exampleのデータベースポートとアプリ URLを更新
- READMEにローカル開発環境セットアップ手順を追加

Fixes #22

Generated with [Claude Code](https://claude.ai/code)